### PR TITLE
Simplify for MVP

### DIFF
--- a/src/schema/ghga.yaml
+++ b/src/schema/ghga.yaml
@@ -145,8 +145,6 @@ classes:
       a single requirement.
     close_mappings:
       - NCIT:C47885
-    slots:
-      - has study
     slot_usage:
       title:
         description: >-

--- a/src/schema/ghga.yaml
+++ b/src/schema/ghga.yaml
@@ -623,6 +623,8 @@ classes:
 
   disease or phenotypic feature:
     is_a: biological quality
+    mixins:
+      - ontology class mixin
     description: >-
       Disease or Phenotypic Feature that the entity is associated with. This entity is a union
       of Disease and Phenotypic Feature and exists to accommodate situations where Disease concepts
@@ -1207,6 +1209,8 @@ classes:
 
   anatomical entity:
     is_a: material entity
+    mixins:
+      - ontology class mixin
     description: >-
       Biological entity that is either an individual member of a biological species or constitutes
       the structural organization of an individual member of a biological species.

--- a/src/schema/ghga.yaml
+++ b/src/schema/ghga.yaml
@@ -33,7 +33,6 @@ classes:
       of all the other classes.
     slots:
       - id
-      - accession
       - xref
       - type
       - creation date
@@ -144,6 +143,7 @@ classes:
   project:
     is_a: research activity
     mixins:
+      - accession mixin
       - attribute mixin
     description: >-
       Any specifically defined piece of work that is undertaken or attempted to meet
@@ -187,6 +187,7 @@ classes:
   study:
     is_a: investigation
     mixins:
+      - accession mixin
       - publication mixin
       - attribute mixin
       - status mixin
@@ -256,6 +257,8 @@ classes:
 
   experiment:
     is_a: investigation
+    mixins:
+      - accession mixin
     description: >-
       An experiment is an investigation that consists of a coordinated set of
       actions and observations designed to generate data with the goal of verifying,
@@ -566,6 +569,8 @@ classes:
 
   biospecimen:
     is_a: material entity
+    mixins:
+      - accession mixin
     description: >-
           A Biospecimen is any natural material taken from a biological entity (usually a human) for testing,
           diagnostics, treatment, or research purposes. The Biospecimen is linked to the Individual from which
@@ -622,9 +627,6 @@ classes:
       Disease or Phenotypic Feature that the entity is associated with. This entity is a union
       of Disease and Phenotypic Feature and exists to accommodate situations where Disease concepts
       are used interchangeably with Phenotype concepts or vice-versa.
-    slots:
-      - name
-      - description
     union_of:
       - disease
       - phenotypic feature
@@ -633,6 +635,8 @@ classes:
 
   sample:
     is_a: material entity
+    mixins:
+      - accession mixin
     description: >-
       A sample is a limited quantity of something to be used for testing, analysis,
       inspection, investigation, demonstration, or trial use. A sample is prepared from
@@ -700,6 +704,8 @@ classes:
 
   individual:
     is_a: person
+    mixins:
+      - accession mixin
     aliases: ['subject', 'patient']
     description: >-
       An Individual is a Person who is participating in a Study.
@@ -776,6 +782,8 @@ classes:
 
   family:
     is_a: population
+    mixins:
+      - accession mixin
     description: >-
       A domestic group, or a number of domestic groups linked through descent (demonstrated or stipulated)
       from a common ancestor, marriage, or adoption.
@@ -800,6 +808,8 @@ classes:
 
   cohort:
     is_a: population
+    mixins:
+      - accession mixin
     description: >-
       A cohort is a collection of individuals that share a common characteristic/observation
       and have been grouped together for a research study/investigation.
@@ -816,6 +826,8 @@ classes:
 
   file:
     is_a: information content entity
+    mixins:
+    - accession mixin
     aliases: ['file object']
     slots:
       - name
@@ -834,6 +846,8 @@ classes:
 
   analysis:
     is_a: data transformation
+    mixins:
+      - accession mixin
     aliases: ['data analysis']
     description: >-
       An Analysis is a data transformation that transforms input data to output data.
@@ -924,6 +938,7 @@ classes:
   dataset:
     is_a: information content entity
     mixins:
+      - accession mixin
       - publication mixin
       - status mixin
     description: >-
@@ -1063,6 +1078,8 @@ classes:
 
   data access policy:
     is_a: information content entity
+    mixins:
+      - accession mixin
     description: >-
       A Data Access Policy specifies under which circumstances, legal or otherwise,
       a user can have access to one or more Datasets belonging to one or more Studies.
@@ -1103,6 +1120,8 @@ classes:
 
   data access committee:
     is_a: committee
+    mixins:
+      - accession mixin
     description: >-
       A group of members that are delegated to grant access to one or more datasets
       after ensuring the minimum criteria for data sharing has been met, and request
@@ -1347,6 +1366,29 @@ classes:
         description: >-
           The status of a Submission. For example, 'in progress' or 'submitted'.
         range: status_enum
+
+  ontology class mixin:
+    description: Mixin for entities that represent an class/term/concept from an ontology.
+    slots:
+      - id
+      - name
+      - description
+    slot_usage:
+        id:
+          description: >-
+            The Compact UR Identifier (CURIE) that uniquely identifies
+            this ontology class.
+        name:
+          description: >-
+            The name or label (rdfs:label) of an ontology class.
+        description:
+          description: >-
+            The description or definition of an ontology class.
+
+  accession mixin:
+    description: Mixin for entities that can be assigned a GHGA accession.
+    slots:
+      - accession
 
   attribute mixin:
     description: Mixin for entities that can have one or more attributes.

--- a/src/schema/ghga.yaml
+++ b/src/schema/ghga.yaml
@@ -34,17 +34,12 @@ classes:
     slots:
       - id
       - xref
-      - type
       - creation date
       - update date
     slot_usage:
       id:
         description: >-
           The internal unique identifier for an entity.
-      accession:
-        description: >-
-          A unique identifier assigned to an entity for the sole purpose of
-          referring to that entity in a global scope.
       xref:
         description: >-
           Holds one or more database cross references.

--- a/src/schema/ghga.yaml
+++ b/src/schema/ghga.yaml
@@ -36,11 +36,8 @@ classes:
       - accession
       - xref
       - type
-      - has attribute
       - creation date
       - update date
-      - replaces
-      - replaced by
     slot_usage:
       id:
         description: >-
@@ -55,13 +52,6 @@ classes:
       type:
         description: >-
           The type of an entity.
-      has attribute:
-        description: >-
-          Holds one or more Attribute entities that further characterizes this entity.
-        range: attribute
-        multivalued: true
-        inlined: true
-        inlined_as_list: true
       creation date:
         description: >-
           Timestamp (in ISO 8601 format) when the entity was created.
@@ -119,10 +109,6 @@ classes:
     slots:
       - title
       - description
-      - has publication
-      - status
-      - release date
-      - deprecation date
     exact_mappings:
       - SIO:000747
       - OBI:0000066
@@ -150,7 +136,6 @@ classes:
     slots:
       - title
       - description
-      - has publication
     exact_mappings:
       - SEPIO:0000004
     close_mappings:
@@ -158,6 +143,8 @@ classes:
 
   project:
     is_a: research activity
+    mixins:
+      - attribute mixin
     description: >-
       Any specifically defined piece of work that is undertaken or attempted to meet
       a single requirement.
@@ -199,6 +186,11 @@ classes:
 
   study:
     is_a: investigation
+    mixins:
+      - publication mixin
+      - attribute mixin
+      - status mixin
+      - release mixin
     description: >-
       Studies are experimental investigations of a particular phenomenon. It involves a
       detailed examination and analysis of a subject to learn more about the phenomenon
@@ -257,6 +249,10 @@ classes:
         description: >-
           Custom key/value pairs that further characterizes the Study. 
           (e.g.: approaches - single-cell, bulk etc)
+      status:
+        description: >-
+          The status of a Study. For example, 'released' or 'unreleased'.
+        range: status_enum
 
   experiment:
     is_a: investigation
@@ -387,6 +383,8 @@ classes:
 
   protocol:
     is_a: information content entity
+    mixins:
+      - attribute mixin
     aliases: ['library protocol', 'experiment protocol']
     description: >-
       A plan specification which has sufficient level of detail and quantitative information
@@ -464,10 +462,6 @@ classes:
         required: true
       library construction kit manufacturer:
         required: true
-
-
-
-      
       has attribute:
         description: >-
           One or more attributes that further characterizes this Library Preparation Protocol.
@@ -929,6 +923,9 @@ classes:
 
   dataset:
     is_a: information content entity
+    mixins:
+      - publication mixin
+      - status mixin
     description: >-
       A Dataset is a collection of Files that is prepared for distribution.
     exact_mappings:
@@ -937,8 +934,6 @@ classes:
       - title
       - description
       - has file
-      - has publication
-      - status
     slot_usage:
       title:
         required: true
@@ -960,8 +955,6 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
-      status:
-        range: status_enum
 
   experiment dataset:
     is_a: dataset
@@ -1260,6 +1253,8 @@ classes:
         range: user_role_enum
 
   submission:
+    mixins:
+      - status mixin
     description: >-
       A grouping entity that represents information about one or more entities.
       A submission can be considered as a set of inter-related (and inter-connected)
@@ -1276,11 +1271,8 @@ classes:
       - has file
       - has data access policy
       - submission date
-      - status
       - creation date
       - update date
-      - replaces
-      - replaced by
     slot_usage:
       id:
         description: >-
@@ -1351,16 +1343,37 @@ classes:
       update date:
         description: >-
           Timestamp (in ISO 8601 format) when the Submission was updated.
-      replaces:
-        description: >-
-          Refers to a deprecated Submission that is being replaced by the current Submission.
-      replaced by:
-        description: >-
-          Refers to the Submission which replaces a currently deprecated Submission.
       status:
         description: >-
           The status of a Submission. For example, 'in progress' or 'submitted'.
         range: status_enum
+
+  attribute mixin:
+    description: Mixin for entities that can have one or more attributes.
+    slots:
+      - has attribute
+
+  publication mixin:
+    description: >-
+      Mixin for entities that can have one or more publications.
+    slots:
+      - has publication
+
+  deprecated mixin:
+    description: Mixin for entities that can be deprecated.
+    slots:
+      - replaced by
+      - deprecation date
+
+  status mixin:
+    description: Mixin for entities that can have a status.
+    slots:
+      - status
+
+  release mixin:
+    description: Mixin for entities that can be released at a later point in time.
+    slots:
+      - release date
 
 slots:
 
@@ -1425,6 +1438,9 @@ slots:
   has attribute:
     description: Key/value pairs corresponding to an entity.
     range: attribute
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
 
   description:
     description: Description of an entity.
@@ -2042,6 +2058,6 @@ enums:
       unreleased:
         description: Signifies that the entity is submitted but unreleased for public consumption.
       released:
-        description: Signifies that the entity is submitted and released for public conusmption.
+        description: Signifies that the entity is submitted and released for public consumption.
       deprecated:
-        description: Signifies that the entity is deprecated and is replaced by another entity.
+        description: Signifies that the entity is deprecated and may be replaced by another entity.


### PR DESCRIPTION
- Rearranges fields that are likely to be sparse and unnecessary for many of the entities
- Move `accession` slot to an `accession mixin` that can be applied to only those entities that are likely to be assigned an accession
- Remove `accession` from `named thing` entity to avoid it being inherited by all of its descendant
- Create an `ontology class mixin` and apply to entities that are basically a proxy for ontology terms/concepts like `anatomical entity`, `disease`, `phenotypic feature`
- Remove `has study` slot from `project` entity to avoid circular references