### PR TITLE
Fix ontology classes

### DIFF
--- a/scripts/generate_creation_schema.py
+++ b/scripts/generate_creation_schema.py
@@ -59,10 +59,7 @@ def adjust_slot_definitions(
     """
     adjusted_slots = CommentedMap()
     for slot_name, slot_def in schema["slots"].items():
-        if slot_name.startswith("has ") and slot_name not in {
-            "has attribute",
-            "has data use condition",
-        }:
+        if slot_name.startswith("has ") and slot_name not in {"has attribute"}:
             new_slot_def = copy.deepcopy(slot_def)
             if "range" in new_slot_def and new_slot_def["range"] in schema["classes"]:
                 if new_slot_def["range"] in creation_classes:

--- a/src/schema/ghga.yaml
+++ b/src/schema/ghga.yaml
@@ -635,8 +635,9 @@ classes:
           For example, 'UBERON:0008307' indicates that the Biospecimen was extracted from
           the 'Heart Endothelium' of an Individual.
         range: anatomical entity
+        multivalued: true
         inlined: true
-        inlined_as_list: false
+        inlined_as_list: true
       has disease:
         description: >-
           The Disease entity that is associated with the Individual. Typically, a concept
@@ -731,8 +732,9 @@ classes:
         inlined_as_list: false
       has anatomical entity:
         range: anatomical entity
+        multivalued: true
         inlined: true
-        inlined_as_list: false
+        inlined_as_list: true
 
   individual:
     is_a: person
@@ -749,7 +751,7 @@ classes:
       - age
       - vital status
       - geographical region
-      - ancestry
+      - has ancestry
       - has parent
       - has children
       - has disease
@@ -857,6 +859,17 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
+
+  ancestry:
+    is_a: population
+    mixins:
+      - ontology class mixin
+    description: >-
+      Population category defined using ancestry informative markers (AIMs) based
+      on genetic/genomic data.
+    aliases: ['ancestral group', 'ancestry category']
+    exact_mappings:
+      - HANCESTRO:0004
 
   file:
     is_a: information content entity
@@ -1084,23 +1097,21 @@ classes:
         range: release_status_enum
 
   data use condition:
+    is_a: information content entity
     description: >-
-      Data Use Condition represents the use conditions associated with a Dataset.
-      A permission field can have one or more terms that collectively defines the
-      data use condition. The modifier determines the interpretation of the use
-      permission(s).
+      Data Use Condition represents the use conditions associated with a policy.
     slots:
-      - permission
-      - modifier
+      - has data use permission
+      - has data use modifier
     slot_usage:
-      - permission:
-          description: >-
-            Data use permission. Typically one or more terms from DUO.
-            Preferably descendants of 'DUO:0000001 data use permission'.
-      - modifier:
-          description: >-
-            Modifier for Data use permission.
-            Preferable descendants of 'DUO:0000017 data use modifier'
+      has data use permission:
+        description: >-
+          Data use permission associated with a policy. Typically one or more terms from DUO
+          and should be descendants of 'DUO:0000001 data use permission'.
+      has data use modifier:
+        description: >-
+          Modifier for Data use permission associated with a policy.
+          Should be descendants of 'DUO:0000017 data use modifier'
 
   data access policy:
     is_a: information content entity
@@ -1287,6 +1298,8 @@ classes:
         range: user_role_enum
 
   submission:
+    mixins:
+      - metadata mixin
     description: >-
       A grouping entity that represents information about one or more entities.
       A submission can be considered as a set of inter-related (and inter-connected)
@@ -1381,6 +1394,25 @@ classes:
           The status of a Submission.
         range: submission_status_enum
 
+  data use permission:
+    is_a: information content entity
+    mixins:
+      - ontology class mixin
+    description: >-
+      A data item that is used to indicate consent permissions for datasets and/or materials
+      and relates to the purposes for which datasets and/or material might be removed, stored or used.
+    exact_mappings:
+      - DUO:0000001
+
+  data use modifier:
+    is_a: information content entity
+    mixins:
+      - ontology class mixin
+    description: >-
+      Data use modifiers indicate additional conditions for use.
+    exact_mappings:
+      - DUO:0000017
+
   ontology class mixin:
     mixin: true
     description: Mixin for entities that represent an class/term/concept from an ontology.
@@ -1388,6 +1420,8 @@ classes:
       - id
       - name
       - description
+      - ontology name
+      - ontology version
     slot_usage:
         id:
           description: >-
@@ -1767,14 +1801,22 @@ slots:
     description: The Individual that is reported to have a disorder in a Family.
     range: individual
 
-  permission:
-    description: Data use permission.
+  has data use permission:
+    description: >-
+      Data use permission associated with an entity. Typically one or more terms from DUO.
+      Should be descendants of 'DUO:0000001 data use permission'.
+    range: data use permission
+    inlined: true
     in_subset:
       - recommended
       - restricted
 
-  modifier:
-    description: Modifier for Data user permission.
+  has data use modifier:
+    description: >-
+      Modifier for Data use permission associated with an entity.
+      Should be descendants of 'DUO:0000017 data use modifier'
+    range: data use modifier
+    inlined: true
     in_subset:
       - recommended
       - restricted
@@ -1834,11 +1876,14 @@ slots:
       - essential
       - restricted
 
-  ancestry:
+  has ancestry:
     description: >-
       A person's descent or lineage, from a person or from a population.
       Typically this is a value from HANCESTRO (Human Ancestry Ontology).
+    range: ancestry
     multivalued: true
+    inlined: true
+    inlined_as_list: true
     in_subset:
       - optional
       - restricted
@@ -2201,6 +2246,14 @@ slots:
       Refers to a deprecated entity that is being replaced by the current entity.
     domain: named thing
     range: named thing
+
+  ontology name:
+    description: >-
+      The name of the ontology from which this ontology class was chosen.
+
+  ontology version:
+    description: >-
+      The version of the ontology from which this ontology class was chosen.
 
 enums:
   case_control_enum:


### PR DESCRIPTION
- Add `ancestry`, `data use permission`, `data use modifier` classes
- Add `has data user permission` and `has data use modifier` slots
- Add `has ancestry` that refers to the ancestral group an individual is part of
- Reorganize classes that are ontology classes
- Add `schema mixin` to `submission` class
- Make `has_anatomical_entity` a multivalued field