### PR TITLE
Feature/slot cleanup gdev 1654

### DIFF
--- a/docs/entity_relations.md
+++ b/docs/entity_relations.md
@@ -138,11 +138,7 @@ Submission {
     string id  
     string affiliation  
     string submission_date  
-    string creation_date  
-    string update_date  
     string submission_status  
-    string schema_type  
-    string schema_version  
 }
 Publication {
     string title  
@@ -150,13 +146,10 @@ Publication {
     string author  
     integer year  
     string journal  
+    string doi  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataAccessCommittee {
     string name  
@@ -166,10 +159,6 @@ DataAccessCommittee {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Attribute {
     string key  
@@ -187,10 +176,6 @@ Member {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataAccessPolicy {
     string name  
@@ -203,10 +188,6 @@ DataAccessPolicy {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataUseModifier {
     string id  
@@ -217,10 +198,6 @@ DataUseModifier {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataUsePermission {
     string id  
@@ -231,10 +208,6 @@ DataUsePermission {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Dataset {
     string title  
@@ -242,18 +215,11 @@ Dataset {
     stringList type  
     string accession  
     string ega_accession  
-    string release_status
-    string release_date  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 File {
-    string drs_uri  
     string name  
     string file_format
     integer size  
@@ -264,10 +230,6 @@ File {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Analysis {
     string type  
@@ -280,27 +242,17 @@ Analysis {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Study {
     string study_type
     stringList affiliation  
     string accession  
     string ega_accession  
-    string release_status
-    string release_date  
     string title  
     string description  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Project {
     string accession  
@@ -309,10 +261,6 @@ Project {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Sample {
     string name  
@@ -327,10 +275,6 @@ Sample {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Biospecimen {
     string name  
@@ -342,10 +286,6 @@ Biospecimen {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Individual {
     string biological_sex
@@ -361,10 +301,6 @@ Individual {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 PhenotypicFeature {
     string id  
@@ -375,10 +311,6 @@ PhenotypicFeature {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Disease {
     string id  
@@ -389,10 +321,6 @@ Disease {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Ancestry {
     string id  
@@ -404,10 +332,6 @@ Ancestry {
     string name  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 AnatomicalEntity {
     string id  
@@ -418,16 +342,11 @@ AnatomicalEntity {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Experiment {
     string type  
     string biological_replicates  
     string technical_replicates  
-    string experimental_replicates  
     string accession  
     string ega_accession  
     string title  
@@ -435,10 +354,6 @@ Experiment {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Protocol {
     string name  
@@ -448,10 +363,6 @@ Protocol {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 
 Submission ||--|| Study : "has study"
@@ -561,9 +472,6 @@ OntologyClassMixin {
 Attribute {
 
 }
-MetadataMixin {
-
-}
 AccessionMixin {
 
 }
@@ -574,9 +482,6 @@ AttributeMixin {
 
 }
 DeprecatedMixin {
-
-}
-ReleaseStatusMixin {
 
 }
 
@@ -596,10 +501,6 @@ NamedThing {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Person {
     string given_name  
@@ -608,56 +509,32 @@ Person {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Committee {
     string name  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 MaterialEntity {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 BiologicalQuality {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 InformationContentEntity {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 PlannedProcess {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Investigation {
     string title  
@@ -665,10 +542,6 @@ Investigation {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataTransformation {
     string title  
@@ -676,10 +549,6 @@ DataTransformation {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 ResearchActivity {
     string title  
@@ -687,10 +556,6 @@ ResearchActivity {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Protocol {
     string name  
@@ -700,20 +565,12 @@ Protocol {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Population {
     string name  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DiseaseOrPhenotypicFeature {
     string id  
@@ -724,10 +581,6 @@ DiseaseOrPhenotypicFeature {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 OntologyClassMixin {
     string id  
@@ -743,10 +596,6 @@ Attribute {
     string value  
     string value_type  
 }
-MetadataMixin {
-    string schema_type  
-    string schema_version  
-}
 AccessionMixin {
     string accession  
 }
@@ -758,10 +607,6 @@ AttributeMixin {
 }
 DeprecatedMixin {
     string deprecation_date  
-}
-ReleaseStatusMixin {
-    string release_status  
-    string release_date  
 }
 
 Protocol ||--}| Attribute : "has attribute"
@@ -905,11 +750,7 @@ Submission {
     string id  
     string affiliation  
     string submission_date  
-    string creation_date  
-    string update_date  
     string submission_status  
-    string schema_type  
-    string schema_version  
 }
 Publication {
     string title  
@@ -917,13 +758,10 @@ Publication {
     string author  
     integer year  
     string journal  
+    string doi  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataAccessCommittee {
     string name  
@@ -934,10 +772,6 @@ DataAccessCommittee {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Attribute {
     string key  
@@ -956,10 +790,6 @@ DataAccessPolicy {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataUseModifier {
     string id  
@@ -970,10 +800,6 @@ DataUseModifier {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 DataUsePermission {
     string id  
@@ -984,10 +810,6 @@ DataUsePermission {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Dataset {
     string title  
@@ -995,18 +817,11 @@ Dataset {
     stringList type  
     string accession  
     string ega_accession  
-    string release_status
-    string release_date  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 File {
-    string drs_uri  
     string name  
     string file_format
     integer size  
@@ -1017,10 +832,6 @@ File {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Analysis {
     string type  
@@ -1033,27 +844,17 @@ Analysis {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Study {
     string study_type
     stringList affiliation  
     string accession  
     string ega_accession  
-    string release_status
-    string release_date  
     string title  
     string description  
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Project {
     string accession  
@@ -1062,10 +863,6 @@ Project {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Sample {
     string name  
@@ -1080,10 +877,6 @@ Sample {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Biospecimen {
     string name  
@@ -1095,10 +888,6 @@ Biospecimen {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Individual {
     string biological_sex
@@ -1114,10 +903,6 @@ Individual {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 PhenotypicFeature {
     string id  
@@ -1128,10 +913,6 @@ PhenotypicFeature {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Disease {
     string id  
@@ -1142,10 +923,6 @@ Disease {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Ancestry {
     string id  
@@ -1157,10 +934,6 @@ Ancestry {
     string name  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 AnatomicalEntity {
     string id  
@@ -1171,16 +944,11 @@ AnatomicalEntity {
     string ontology_version  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Experiment {
     string type  
     string biological_replicates  
     string technical_replicates  
-    string experimental_replicates  
     string accession  
     string ega_accession  
     string title  
@@ -1188,10 +956,6 @@ Experiment {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 Protocol {
     string name  
@@ -1201,10 +965,6 @@ Protocol {
     string id  
     string alias  
     stringList xref  
-    string creation_date  
-    string update_date  
-    string schema_type  
-    string schema_version  
 }
 
 Submission ||--|| Study : "has study"

--- a/src/schema/advance_schema.yaml
+++ b/src/schema/advance_schema.yaml
@@ -35,15 +35,6 @@ classes:
     exact_mappings:
       - prov:Agent
 
-  technology:
-    is_a: information content entity
-    deprecated: true
-    description: >-
-      A Technology is an abstraction that represents the instrument used for an assay. The Technology
-      entity captures instrument-specific attributes that are relevant for an Experiment entity.
-      The Technology entity may be further characterized by its children where each child has fields
-      that are relevant to that particular technology.
-
   experiment process:
     is_a: experiment
     mixins:
@@ -283,10 +274,6 @@ slots:
   role:
     description: The role that a user has within GHGA.
     range: user role enum
-
-  has technology:
-    deprecated: true
-    range: technology
 
   has experiment process:
     range: experiment process

--- a/src/schema/base_schema.yaml
+++ b/src/schema/base_schema.yaml
@@ -30,8 +30,6 @@ subsets:
 
 classes:
   named thing:
-    mixins:
-      - metadata mixin
     abstract: true
     aliases: ["named entity", "entity", "object"]
     description: >-
@@ -41,8 +39,6 @@ classes:
       - id
       - alias
       - xref
-      - creation date
-      - update date
     slot_usage:
       id:
         description: >-
@@ -55,14 +51,6 @@ classes:
       xref:
         description: >-
           Holds one or more database cross references for an entity.
-        required: true
-      creation date:
-        description: >-
-          Timestamp (in ISO 8601 format) when the entity was created.
-        required: true
-      update date:
-        description: >-
-          Timestamp (in ISO 8601 format) when the entity was updated.
         required: true
 
   person:
@@ -319,18 +307,6 @@ classes:
           a percentage.
         required: false
 
-  metadata mixin:
-    mixin: true
-    description: Mixin for tracking schema specific metadata about an instance.
-    slots:
-      - schema type
-      - schema version
-    slot_usage:
-      schema type:
-        required: true
-      schema version:
-        required: true
-
   accession mixin:
     mixin: true
     description: Mixin for entities that can be assigned a GHGA accession.
@@ -370,30 +346,7 @@ classes:
       deprecation date:
         required: true
 
-  release status mixin:
-    mixin: true
-    description: Mixin for entities that can be released at a later point in time.
-    slots:
-      - release status
-      - release date
-    slot_usage:
-      release status:
-        required: true
-      release date:
-        required: true
-
 slots:
-  update date:
-    description: Timestamp (in ISO 8601 format) when the entity was updated.
-
-  creation date:
-    description: Timestamp (in ISO 8601 format) when the entity was created.
-
-  schema type:
-    description: The schema type an instance corresponds to.
-
-  schema version:
-    description: The version of the schema an instance corresponds to.
 
   id:
     description: An identifier that uniquely represents an entity.
@@ -457,14 +410,6 @@ slots:
   category:
     description: >-
       The category for this file: Whole Genome Sequencing, Whole Exome Sequencing, etc.
-
-  release status:
-    description: >-
-      The release status of an entity.
-
-  release date:
-    description: >-
-      The timestamp (in ISO 8601 format) when the entity was released for public consumption.
 
   deprecation date:
     description: >-

--- a/src/schema/submission_centric_schema.yaml
+++ b/src/schema/submission_centric_schema.yaml
@@ -43,7 +43,6 @@ classes:
       - accession mixin
       - ega accession mixin
       - attribute mixin
-      - release status mixin
     description: >-
       Studies are experimental investigations of a particular phenomenon. It involves a
       detailed examination and analysis of a subject to learn more about the phenomenon
@@ -85,11 +84,6 @@ classes:
         description: >-
           Custom key/value pairs that further characterizes the Study.
           (e.g.: approaches - single-cell, bulk etc)
-      release status:
-        description: >-
-          The release status of a Study.
-        range: release status enum
-        required: true
       has file:
         description: >-
           Additional/supplementary files associated with a Study.
@@ -114,7 +108,6 @@ classes:
       - type
       - biological replicates
       - technical replicates
-      - experimental replicates
       - has study
       - has sample
       - has file
@@ -134,8 +127,6 @@ classes:
       biological replicates:
         required: false
       technical replicates:
-        required: false
-      experimental replicates:
         required: false
       has study:
         description: >-
@@ -228,7 +219,6 @@ classes:
     slots:
       - sequencing center
       - instrument model
-      - paired or single end
       - forward or reverse
       - sequencing read length
       - index sequence
@@ -259,9 +249,6 @@ classes:
         description: >-
           One or more attributes that further characterizes this Sequencing Protocol.
       sequencing center:
-        required: false
-        recommended: true
-      paired or single end:
         required: false
         recommended: true
       forward or reverse:
@@ -550,7 +537,6 @@ classes:
       A file is an object that contains information generated from a process, either an
       Experiment or an Analysis.
     slots:
-      - drs uri
       - name
       - format
       - size
@@ -563,8 +549,6 @@ classes:
         required: true
       format:
         required: true
-      drs uri:
-        required: false
       checksum:
         required: true
       checksum type:
@@ -633,7 +617,6 @@ classes:
     mixins:
       - accession mixin
       - ega accession mixin
-      - release status mixin
       - attribute mixin
     description: >-
       A Dataset is a collection of Files that is prepared for distribution
@@ -710,11 +693,6 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
-      release status:
-        description: >-
-          The release status of a Dataset.
-        required: false
-        range: release status enum
 
   data use permission:
     is_a: information content entity
@@ -838,6 +816,7 @@ classes:
       - author
       - year
       - journal
+      - doi
     slot_usage:
       title:
         description: >-
@@ -857,11 +836,13 @@ classes:
         description: >-
           One or more cross-references for this Publication.
         required: false
+      doi:
+        description:
+          DOI identifier of the Publication.
+        required: true
 
   submission:
     tree_root: true
-    mixins:
-      - metadata mixin
     description: >-
       A grouping entity that represents information about one or more entities.
       A submission can be considered as a set of inter-related (and inter-connected)
@@ -883,8 +864,6 @@ classes:
       - has data access committee
       - has publication
       - submission date
-      - creation date
-      - update date
       - submission status
     slot_usage:
       id:
@@ -984,14 +963,6 @@ classes:
         multivalued: true
         inlined: true
         inlined_as_list: true
-      creation date:
-        description: >-
-          Timestamp (in ISO 8601 format) when the Submission was created.
-        required: false
-      update date:
-        description: >-
-          Timestamp (in ISO 8601 format) when the Submission was updated.
-        required: false
       submission status:
         description: >-
           The status of a Submission.
@@ -1164,20 +1135,12 @@ slots:
     exact_mappings:
       - EFO:0002090
 
-
   biological replicates:
     description: >-
       A biological replicate is a replicate role that consists of
       independent biological replicates made from different individual biosamples.
     exact_mappings:
       - EFO:0002091
-
-  experimental replicates:
-    description: >-
-      The replicate number of the assay, i.e. the numeric iteration
-      for the assay that was repeated.
-    exact_mappings:
-      - NCIT:C178859
 
   library name:
     description: >-
@@ -1256,13 +1219,6 @@ slots:
       A unique nucleotide sequence that is added to a sample during library preparation to serve as a unique identifier for the sample.
     exact_mappings:
       - NCIT:C165443
-
-  paired or single end:
-    deprecated: true
-    description: >-
-      Denotes whether a submitted FASTQ file contains forward (R1) or reverse (R2) reads for paired-end sequencing.
-      The number that identifies each read direction in a paired-end nucleotide sequencing replications.
-    range: paired or single end enum
 
   forward or reverse:
     description: >-
@@ -1396,10 +1352,6 @@ slots:
     description: >-
       The type of algorithm used to generate the checksum of a file.
 
-  drs uri:
-    description: >-
-      GA4GH Data Repository Service (DRS) identifier URI for a file.
-
   reference chromosome:
     description: >-
       The reference chromosome used for this Analysis.
@@ -1454,6 +1406,10 @@ slots:
   submission date:
     description: >-
       The timestamp (in ISO 8601 format) when submission was marked completed.
+
+  doi:
+    description: >-
+      DOI identifier of a publication.
 
 enums:
   biological sex enum:
@@ -1556,15 +1512,6 @@ enums:
         description: The Sample is to be treated as Control
       case:
         description: The Sample is to be treated as Case
-  paired or single end enum:
-    deprecated: true
-    description: >-
-      Enum to capture whether a sequencing experiment generates reads that are Paired-end or Single-end.
-    permissible_values:
-      paired:
-        description: The reads are Paired-end
-      single:
-        description: The reads are Single-end
   forward or reverse enum:
     description: >-
       Enum to capture whether the reads from paired-end sequencing are forward (R1) or reverse (R2).
@@ -1573,14 +1520,6 @@ enums:
         description: The reads are forward (R1) reads
       reverse:
         description: The reads are reverse (R2) reads
-  release status enum:
-    description: >-
-      Enum to capture the release status of an entity.
-    permissible_values:
-      unreleased:
-        description: signifies that the entity has not yet been release for public consumption.
-      released:
-        description: signifies that the entity has been release for public consumption.
   age range enum:
     description: >-
       Enum to capture the age range that an Indiviudal belongs to.


### PR DESCRIPTION
Fixes GDEV 1654  #

## Proposed Changes

  - removed: release status, release date, update date, creation date, schema version, schema type and corresponding mixins, experimental replicates, paired or single end plus enum, technology, drs uri
  - added: doi to publication

