### PR TITLE
Refactor relations config

### DIFF
--- a/relations_config.yaml
+++ b/relations_config.yaml
@@ -1,95 +1,139 @@
 classes:
 - name: Attribute
-  relations: []
+  relations: {}
 - name: AliasMixin
-  relations: []
+  relations: {}
 - name: AttributeMixin
   relations:
-  - attributes
+    attributes:
+      targetClass: Attribute
 - name: Study
-  relations: []
+  relations: {}
 - name: SequencingExperiment
   relations:
-  - sequencing_protocol
-  - library_preparation_protocol
+    library_preparation_protocol:
+      targetClass: LibraryPreparationProtocol
+    sequencing_protocol:
+      targetClass: SequencingProtocol
 - name: Condition
   relations:
-  - study
+    study:
+      targetClass: Study
 - name: LibraryPreparationProtocol
-  relations: []
+  relations: {}
 - name: SequencingProtocol
-  relations: []
+  relations: {}
 - name: SequencingProcess
   relations:
-  - sequencing_experiment
-  - sample
+    sample:
+      targetClass: Sample
+    sequencing_experiment:
+      targetClass: SequencingExperiment
 - name: Biospecimen
   relations:
-  - individual
+    individual:
+      targetClass: Individual
 - name: Sample
   relations:
-  - biospecimen
-  - condition
+    biospecimen:
+      targetClass: Biospecimen
+    condition:
+      targetClass: Condition
 - name: Individual
-  relations: []
+  relations: {}
 - name: Trio
   relations:
-  - mother
-  - father
-  - child
+    child:
+      targetClass: Individual
+    father:
+      targetClass: Individual
+    mother:
+      targetClass: Individual
 - name: File
   relations:
-  - dataset
+    dataset:
+      targetClass: Dataset
 - name: StudyFile
   relations:
-  - study
+    study:
+      targetClass: Study
 - name: SampleFile
   relations:
-  - sample
+    sample:
+      targetClass: Sample
 - name: SequencingProcessFile
   relations:
-  - sequencing_process
+    sequencing_process:
+      targetClass: SequencingProcess
 - name: AnalysisProcessOutputFile
   relations:
-  - analysis_process
+    analysis_process:
+      targetClass: AnalysisProcess
 - name: Analysis
-  relations: []
+  relations: {}
 - name: AnalysisProcess
   relations:
-  - analysis
-  - study_input_files
-  - sample_input_files
-  - sequencing_process_input_files
+    analysis:
+      targetClass: Analysis
+    sample_input_files:
+      targetClass: SampleFile
+    sequencing_process_input_files:
+      targetClass: SequencingProcessFile
+    study_input_files:
+      targetClass: StudyFile
 - name: Dataset
   relations:
-  - data_access_policy
+    data_access_policy:
+      targetClass: DataAccessPolicy
 - name: DataAccessPolicy
   relations:
-  - data_access_committee
+    data_access_committee:
+      targetClass: DataAccessCommittee
 - name: DataAccessCommittee
-  relations: []
+  relations: {}
 - name: Publication
   relations:
-  - study
+    study:
+      targetClass: Study
 - name: Submission
   relations:
-  - analyses
-  - analysis_process_output_files
-  - analysis_processes
-  - biospecimens
-  - conditions
-  - data_access_committees
-  - data_access_policies
-  - datasets
-  - individuals
-  - library_preparation_protocols
-  - publications
-  - sample_files
-  - samples
-  - sequencing_experiments
-  - sequencing_process_files
-  - sequencing_processes
-  - sequencing_protocols
-  - studies
-  - study_files
-  - trios
+    analyses:
+      targetClass: Analysis
+    analysis_process_output_files:
+      targetClass: AnalysisProcessOutputFile
+    analysis_processes:
+      targetClass: AnalysisProcess
+    biospecimens:
+      targetClass: Biospecimen
+    conditions:
+      targetClass: Condition
+    data_access_committees:
+      targetClass: DataAccessCommittee
+    data_access_policies:
+      targetClass: DataAccessPolicy
+    datasets:
+      targetClass: Dataset
+    individuals:
+      targetClass: Individual
+    library_preparation_protocols:
+      targetClass: LibraryPreparationProtocol
+    publications:
+      targetClass: Publication
+    sample_files:
+      targetClass: SampleFile
+    samples:
+      targetClass: Sample
+    sequencing_experiments:
+      targetClass: SequencingExperiment
+    sequencing_process_files:
+      targetClass: SequencingProcessFile
+    sequencing_processes:
+      targetClass: SequencingProcess
+    sequencing_protocols:
+      targetClass: SequencingProtocol
+    studies:
+      targetClass: Study
+    study_files:
+      targetClass: StudyFile
+    trios:
+      targetClass: Trio

--- a/scripts/extract_class_content.py
+++ b/scripts/extract_class_content.py
@@ -32,14 +32,24 @@ def load_yaml(path: Path):
     return data
 
 
+def _reshaped_relation(path: Path = RELATIONS_CONFIG):
+    """reshapes the relations, converts them from a nested structure to a simple
+    list with relation names"""
+    data = load_yaml(path)
+    return [
+        {"name": info["name"], "relations": info["relations"].keys()}
+        for info in data["classes"]
+    ]
+
+
 def load_config():
     """Loads the relations from relations_config.yaml"""
 
     def _construct_config(relations_config):
         return TypeAdapter(list[Relation]).validate_python(relations_config)
 
-    relations_config = load_yaml(RELATIONS_CONFIG)
-    return _construct_config(relations_config["classes"])
+    relations_config = _reshaped_relation()
+    return _construct_config(relations_config)
 
 
 def linkml_to_json(file: Path) -> dict:

--- a/scripts/extract_relations.py
+++ b/scripts/extract_relations.py
@@ -3,6 +3,7 @@
 
 from pathlib import Path
 from typing import Any, Union
+
 import yaml
 from pydantic import BaseModel, Field
 from script_utils.cli import run
@@ -13,11 +14,11 @@ class SchemaClass(BaseModel):
 
     name: str
     slots: list
-    relations: list[Union[Any, str]] = Field(default_factory=list)
+    relations: dict[str, dict] = Field(default_factory=dict)
 
 
 class Schema(BaseModel):
-    """Model describing a basic linkML schema """
+    """Model describing a basic linkML schema"""
 
     json_schema: dict[str, Any]
     classes: list[SchemaClass]
@@ -62,13 +63,13 @@ def slots_with_class_range(schema: Schema) -> dict:
     }
 
 
-def class_relations(schema_class: SchemaClass, class_ranged_slots: dict) -> list:
+def class_relations(schema_class: SchemaClass, class_ranged_slots: dict) -> dict:
     """Extracts the classes that a given class is in relation with"""
-    return [
-        slot
+    return {
+        slot: {"targetClass": class_ranged_slots[slot]}
         for slot in schema_class.slots
         if slot in class_ranged_slots
-    ]
+    }
 
 
 def save_relations(schema: Schema, filename: str):


### PR DESCRIPTION
In LinkML, the class relations are represented with a slot name that has a class range. Since the slot name is different from the target class, that has the potential to hinder the schemapack conversion of the corresponding metadata model. Hence, I refactored the configuration, using the slot name as the relation name and the range as the target class. Further schemapack relation specifications (i.e., mandatory, multiple) are not a part of the relations config. 